### PR TITLE
remove duplicate parameter

### DIFF
--- a/lib/src/widgets/chat.dart
+++ b/lib/src/widgets/chat.dart
@@ -39,7 +39,6 @@ class Chat extends StatefulWidget {
     this.customDateHeaderText,
     this.customMessageBuilder,
     this.customStatusBuilder,
-    this.customTypingIndicator,
     this.dateFormat,
     this.dateHeaderBuilder,
     this.dateHeaderThreshold = 900000,
@@ -124,9 +123,6 @@ class Chat extends StatefulWidget {
   /// See [Message.customStatusBuilder].
   final Widget Function(types.Message message, {required BuildContext context})?
       customStatusBuilder;
-
-  /// Allows you to replace default [TypingIndicator] widget.
-  final Widget? customTypingIndicator;
 
   /// Allows you to customize the date format. IMPORTANT: only for the date,
   /// do not return time here. See [timeFormat] to customize the time format.


### PR DESCRIPTION
### PR Description
**Change:** ```customTypingIndicator``` exists as Chat widget parameter. It isn't needed here as it exists in ```typingIndicatorOptions```. 